### PR TITLE
feat: kiosk polish — confirm appointment time, no-scroll layout, phys…

### DIFF
--- a/src/app/admin/patient-signin/page.tsx
+++ b/src/app/admin/patient-signin/page.tsx
@@ -3,8 +3,10 @@ import SignInKeypad from "@/components/signin-keypad";
 
 export default function Page() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen p-4 pb-10 sm:p-10 mt-12">
-      <main className="flex flex-col gap-[24px] row-start-2 items-center sm:items-start">
+    // Kiosk: exactly one viewport tall, never scrolls. pt-28 clears the
+    // fixed header (py-4 + 80px logo ≈ 112px).
+    <div className="h-dvh overflow-hidden flex flex-col items-center justify-center px-4 pb-4 pt-28">
+      <main className="flex flex-col items-center">
         <SignInKeypad />
       </main>
     </div>

--- a/src/components/confirmation-modal.tsx
+++ b/src/components/confirmation-modal.tsx
@@ -54,8 +54,6 @@ export default function ConfirmationModal({
     }
   }, [showSuccess, onClose]);
 
-  if (!isVisible && !isOpen) return null;
-
   const handleConfirm = async () => {
     setSaving(true);
     const result = await onConfirm();
@@ -67,6 +65,27 @@ export default function ConfirmationModal({
       setShowSuccess(true);
     }
   };
+
+  // Numpad-only check-in: Enter confirms, Escape declines. Re-subscribes
+  // every render so the handler sees current state.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (saving || showSuccess) return;
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (failed) onClose();
+        else handleConfirm();
+      } else if (e.key === "Escape") {
+        if (failed) onClose();
+        else onDeny();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
+  if (!isVisible && !isOpen) return null;
 
   const displayName = lastName
     ? `${firstName} ${lastName.charAt(0)}.`
@@ -114,12 +133,19 @@ export default function ConfirmationModal({
             </p>
           ) : firstName ? (
             <>
-              <h2 className="text-4xl font-semibold mb-6">Is this you?</h2>
+              <h2 className="text-4xl font-semibold mb-6">
+                {appointmentTime ? "Is this your appointment?" : "Is this you?"}
+              </h2>
               <p className="text-3xl mb-3">{displayName}</p>
-              {appointmentTime && (
-                <p className="text-xl text-gray-600 dark:text-gray-300">
-                  Appointment at {appointmentTime}
+              {appointmentTime ? (
+                <p className="text-2xl">
+                  Today at <strong>{appointmentTime}</strong>
                   {practitioner ? ` with ${practitioner}` : ""}
+                </p>
+              ) : (
+                <p className="text-lg text-gray-600 dark:text-gray-300">
+                  We couldn&apos;t find a booked appointment for today — you can
+                  still sign in.
                 </p>
               )}
             </>

--- a/src/components/signin-keypad.tsx
+++ b/src/components/signin-keypad.tsx
@@ -315,6 +315,39 @@ export default function SignInKeypad() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Physical keyboard / numpad support on the PIN screens. The contact
+  // screen types into a real input, so keystrokes focused there are left
+  // alone. Re-subscribes every render so the handlers see current state.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      ) {
+        return;
+      }
+      const isPinEntry = screen === "pin_entry";
+      const isNewPin =
+        screen === "new_pin_create" || screen === "new_pin_confirm";
+      if (!isPinEntry && !isNewPin) return;
+
+      if (/^[0-9]$/.test(e.key)) {
+        e.preventDefault();
+        if (isPinEntry) handlePinDigit(e.key);
+        else handleNewPinDigit(e.key);
+      } else if (e.key === "Backspace" || e.key === "Delete") {
+        e.preventDefault();
+        if (isPinEntry) handlePinBackspace();
+        else handleNewPinBackspace();
+      } else if (e.key === "Escape") {
+        if (isPinEntry) handlePinClear();
+        else handleNewPinClear();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
   // --- PIN display helper ---
 
   const pinDots = (value: string) =>


### PR DESCRIPTION
…ical numpad

- Confirm modal now asks "Is this your appointment?" with the time shown prominently; honest fallback note when no appointment is found
- Sign-in page is exactly one viewport tall (h-dvh, padding clears the fixed header) so the kiosk never scrolls
- Physical numpad works end to end: digits/Backspace/Escape on the PIN screens, Enter confirms and Escape declines on the modal