### PR TITLE
fix: log Supabase error details when form rate limiter fails closed

### DIFF
--- a/src/lib/form-rate-limit.ts
+++ b/src/lib/form-rate-limit.ts
@@ -17,7 +17,10 @@ export async function formSubmissionsExhausted(ip: string): Promise<boolean> {
     .eq("ip", ip)
     .gte("submitted_at", cutoff);
   if (error || count === null) {
-    console.error("Form rate-limit counter unreadable — failing closed");
+    console.error(
+      "Form rate-limit counter unreadable — failing closed:",
+      error ? `${error.code} ${error.message}` : "null count"
+    );
     return true;
   }
   return count >= MAX_PER_WINDOW;
@@ -28,7 +31,11 @@ export async function recordFormSubmission(ip: string): Promise<void> {
   const { error } = await supabase
     .from("form_submission_events")
     .insert({ ip, submitted_at: new Date().toISOString() });
-  if (error) console.error("Failed to record form submission:", error.code);
+  if (error)
+    console.error(
+      "Failed to record form submission:",
+      `${error.code} ${error.message}`
+    );
   await supabase
     .from("form_submission_events")
     .delete()


### PR DESCRIPTION
The fail-closed 429 path in `src/lib/form-rate-limit.ts` logged a fixed string with no detail about why the counter was unreadable. That made the missing `form_submission_events` table (migration 0006 not yet applied — the cause of the "Too many requests" outage on the appointment request form, fixed 2026-07-17) indistinguishable from genuine rate limiting in the Vercel logs.

Now both the counter read and the submission insert log the PostgREST error code and message, so a schema/connectivity problem is identifiable at a glance.

No behavior change — the limiter still fails closed. Typecheck and vitest (10/10) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)