### PR TITLE
fix: lint commas blocking production build (branched from main)

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -32,10 +32,10 @@ export default function Footer() {
             end: "bottom bottom",
             scrub: 0.4,
           },
-        },
+        }
       );
     },
-    { scope: root, dependencies: [reduced] },
+    { scope: root, dependencies: [reduced] }
   );
 
   return (

--- a/src/lib/form-rate-limit.ts
+++ b/src/lib/form-rate-limit.ts
@@ -19,7 +19,7 @@ export async function formSubmissionsExhausted(ip: string): Promise<boolean> {
   if (error || count === null) {
     console.error(
       "Form rate-limit counter unreadable — failing closed:",
-      error ? `${error.code} ${error.message}` : "null count",
+      error ? `${error.code} ${error.message}` : "null count"
     );
     return true;
   }
@@ -34,7 +34,7 @@ export async function recordFormSubmission(ip: string): Promise<void> {
   if (error)
     console.error(
       "Failed to record form submission:",
-      `${error.code} ${error.message}`,
+      `${error.code} ${error.message}`
     );
   await supabase
     .from("form_submission_events")


### PR DESCRIPTION
PR #24 squash-merged without actually applying the comma fixes — repeated dev→main squash merges left git computing the diff from a stale merge base (8bd9d67), and the four changed lines resolved toward main's side. This branch is cut directly from main with only the 8-line fix, so the diff cannot drift.

After this: production main's tree will be identical to dev's, which passes `next lint`, `tsc --noEmit`, and `next build` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)