### PR TITLE
fix(rooms): QA polish — admin header, DnD editor, alarm cadence, numeric time entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rac-website",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@gsap/react": "^2.1.2",
         "@supabase/supabase-js": "^2.107.0",
         "bcryptjs": "^3.0.3",
@@ -64,6 +65,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:check": "eslint ."
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@gsap/react": "^2.1.2",
     "@supabase/supabase-js": "^2.107.0",
     "bcryptjs": "^3.0.3",

--- a/src/app/admin/rooms/LayoutEditor.tsx
+++ b/src/app/admin/rooms/LayoutEditor.tsx
@@ -1,18 +1,99 @@
 "use client";
 import { useState } from "react";
-import { Move, Trash2 } from "lucide-react";
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { Plus, Trash2 } from "lucide-react";
 import {
   GRID_COLS,
   MAX_DURATION_SECONDS,
   MIN_DURATION_SECONDS,
   RoomRow,
 } from "@/lib/room-status";
+import { gridStyle } from "./grid";
 
 interface PanelState {
   mode: "create" | "edit";
   room?: RoomRow;
+  // Cell preselected by clicking an empty slot; absent when using the
+  // Create room button (first free cell is used at save time).
+  cell?: { gridRow: number; gridCol: number };
+}
+
+// Rooms are dragged; empty cells are drop targets. A small pointer
+// threshold keeps plain clicks (open the edit panel) distinct from drags.
+function DraggableRoom({
+  room,
+  disabled,
+  onEdit,
+}: {
+  room: RoomRow;
+  disabled: boolean;
+  onEdit: (room: RoomRow) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: room.id, disabled });
+  return (
+    <button
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      disabled={disabled}
+      onClick={() => onEdit(room)}
+      style={
+        transform
+          ? {
+              transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+            }
+          : undefined
+      }
+      className={`relative flex h-full w-full touch-none flex-col items-center justify-center gap-1 rounded-2xl bg-neutral-700 p-3 text-center hover:bg-neutral-600 ${
+        isDragging ? "z-10 opacity-80 ring-2 ring-sky-300" : ""
+      }`}
+    >
+      <span className="w-full truncate font-medium">{room.name}</span>
+      {room.practitioner_name && (
+        <span className="w-full truncate text-xs text-white/60">
+          {room.practitioner_name}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function DroppableCell({
+  gridRow,
+  gridCol,
+  disabled,
+  onClick,
+}: {
   gridRow: number;
   gridCol: number;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `cell-${gridRow}-${gridCol}`,
+  });
+  return (
+    <button
+      ref={setNodeRef}
+      disabled={disabled}
+      onClick={onClick}
+      aria-label={`Empty cell row ${gridRow + 1} column ${gridCol + 1}`}
+      className={`h-full w-full rounded-2xl border-2 border-dashed ${
+        isOver
+          ? "border-sky-400 bg-sky-950/40"
+          : "border-neutral-800 hover:border-neutral-600"
+      }`}
+    />
+  );
 }
 
 export default function LayoutEditor({
@@ -41,53 +122,60 @@ export default function LayoutEditor({
   onDelete: (roomId: string) => Promise<void>;
 }) {
   const [panel, setPanel] = useState<PanelState | null>(null);
-  const [movingRoom, setMovingRoom] = useState<RoomRow | null>(null);
   const [name, setName] = useState("");
   const [practitioner, setPractitioner] = useState("");
   const [minutes, setMinutes] = useState(15);
   const [saving, setSaving] = useState(false);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
 
   const maxRow = rooms.reduce((m, r) => Math.max(m, r.grid_row), 0);
   const rowCount = maxRow + 2;
   const byCell = new Map(rooms.map((r) => [`${r.grid_row}:${r.grid_col}`, r]));
 
-  const openCreate = (gridRow: number, gridCol: number) => {
+  const firstFreeCell = () => {
+    for (let gridRow = 0; gridRow < rowCount; gridRow++) {
+      for (let gridCol = 0; gridCol < GRID_COLS; gridCol++) {
+        if (!byCell.has(`${gridRow}:${gridCol}`)) return { gridRow, gridCol };
+      }
+    }
+    return { gridRow: rowCount, gridCol: 0 };
+  };
+
+  const openCreate = (cell?: { gridRow: number; gridCol: number }) => {
     setName("");
     setPractitioner("");
-    setPanel({ mode: "create", gridRow, gridCol });
+    setPanel({ mode: "create", cell });
   };
 
   const openEdit = (room: RoomRow) => {
     setName(room.name);
     setPractitioner(room.practitioner_name ?? "");
     setMinutes(Math.round(room.default_duration_seconds / 60));
-    setPanel({
-      mode: "edit",
-      room,
-      gridRow: room.grid_row,
-      gridCol: room.grid_col,
-    });
+    setPanel({ mode: "edit", room });
   };
 
-  const tapEmptyCell = async (gridRow: number, gridCol: number) => {
-    if (movingRoom) {
-      setSaving(true);
-      await onUpdate(movingRoom.id, { gridRow, gridCol });
-      setSaving(false);
-      setMovingRoom(null);
-      return;
-    }
-    openCreate(gridRow, gridCol);
+  const onDragEnd = async (event: DragEndEvent) => {
+    const match = /^cell-(\d+)-(\d+)$/.exec(String(event.over?.id ?? ""));
+    if (!match || saving) return;
+    setSaving(true);
+    await onUpdate(String(event.active.id), {
+      gridRow: Number(match[1]),
+      gridCol: Number(match[2]),
+    });
+    setSaving(false);
   };
 
   const submitPanel = async () => {
     if (!panel || !name.trim()) return;
     setSaving(true);
     if (panel.mode === "create") {
+      const cell = panel.cell ?? firstFreeCell();
       await onCreate({
         name: name.trim(),
-        gridRow: panel.gridRow,
-        gridCol: panel.gridCol,
+        gridRow: cell.gridRow,
+        gridCol: cell.gridCol,
         practitionerName: practitioner.trim() || undefined,
       });
     } else if (panel.room) {
@@ -106,61 +194,49 @@ export default function LayoutEditor({
 
   return (
     <div className="mx-auto max-w-5xl">
-      {movingRoom && (
-        <p className="mb-3 rounded-lg bg-sky-900/60 px-4 py-2 text-sm">
-          Moving &quot;{movingRoom.name}&quot; — tap an empty cell, or{" "}
-          <button className="underline" onClick={() => setMovingRoom(null)}>
-            cancel
-          </button>
-        </p>
-      )}
-
-      <div className="overflow-x-auto pb-2">
-        <div
-          className="grid gap-3"
-          style={{
-            gridTemplateColumns: `repeat(${GRID_COLS}, minmax(120px, 1fr))`,
-          }}
+      <div className="mb-4 flex items-center gap-3">
+        <button
+          disabled={saving}
+          onClick={() => openCreate()}
+          className="flex items-center gap-1.5 rounded-lg bg-white px-4 py-2 text-sm font-medium text-neutral-900 hover:bg-white/90 disabled:opacity-40"
         >
-          {Array.from({ length: rowCount * GRID_COLS }, (_, i) => {
-            const gridRow = Math.floor(i / GRID_COLS);
-            const gridCol = i % GRID_COLS;
-            const room = byCell.get(`${gridRow}:${gridCol}`);
-            if (room) {
-              return (
-                <button
-                  key={i}
-                  disabled={saving}
-                  onClick={() => openEdit(room)}
-                  className={`min-h-24 rounded-2xl p-3 text-left ${
-                    movingRoom?.id === room.id
-                      ? "bg-sky-700 ring-2 ring-sky-300"
-                      : "bg-neutral-700 hover:bg-neutral-600"
-                  }`}
-                >
-                  <span className="block truncate font-medium">
-                    {room.name}
-                  </span>
-                  {room.practitioner_name && (
-                    <span className="block truncate text-xs text-white/60">
-                      {room.practitioner_name}
-                    </span>
-                  )}
-                </button>
-              );
-            }
-            return (
-              <button
-                key={i}
-                disabled={saving}
-                aria-label={`Empty cell row ${gridRow + 1} column ${gridCol + 1}`}
-                onClick={() => tapEmptyCell(gridRow, gridCol)}
-                className="min-h-24 rounded-2xl border-2 border-dashed border-neutral-800 hover:border-neutral-600"
-              />
-            );
-          })}
-        </div>
+          <Plus className="h-4 w-4" /> Create room
+        </button>
+        <p className="text-xs text-white/50">
+          Drag rooms into position. Click a room to edit it.
+        </p>
       </div>
+
+      <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+        <div className="overflow-x-auto pb-2">
+          <div className="grid gap-3" style={gridStyle}>
+            {Array.from({ length: rowCount * GRID_COLS }, (_, i) => {
+              const gridRow = Math.floor(i / GRID_COLS);
+              const gridCol = i % GRID_COLS;
+              const room = byCell.get(`${gridRow}:${gridCol}`);
+              if (room) {
+                return (
+                  <DraggableRoom
+                    key={room.id}
+                    room={room}
+                    disabled={saving}
+                    onEdit={openEdit}
+                  />
+                );
+              }
+              return (
+                <DroppableCell
+                  key={`empty-${i}`}
+                  gridRow={gridRow}
+                  gridCol={gridCol}
+                  disabled={saving}
+                  onClick={() => openCreate({ gridRow, gridCol })}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </DndContext>
 
       {panel && (
         <div className="fixed inset-0 z-10 flex items-end justify-center bg-black/60 p-4 sm:items-center">
@@ -215,31 +291,19 @@ export default function LayoutEditor({
                 Cancel
               </button>
               {panel.mode === "edit" && panel.room && (
-                <>
-                  <button
-                    aria-label="Move room"
-                    onClick={() => {
-                      setMovingRoom(panel.room!);
-                      setPanel(null);
-                    }}
-                    className="ml-auto rounded-lg bg-white/10 p-2.5"
-                  >
-                    <Move className="h-4 w-4" />
-                  </button>
-                  <button
-                    aria-label="Delete room"
-                    disabled={saving}
-                    onClick={async () => {
-                      setSaving(true);
-                      await onDelete(panel.room!.id);
-                      setSaving(false);
-                      setPanel(null);
-                    }}
-                    className="rounded-lg bg-rose-900/70 p-2.5"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
-                </>
+                <button
+                  aria-label="Delete room"
+                  disabled={saving}
+                  onClick={async () => {
+                    setSaving(true);
+                    await onDelete(panel.room!.id);
+                    setSaving(false);
+                    setPanel(null);
+                  }}
+                  className="ml-auto rounded-lg bg-rose-900/70 p-2.5"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
               )}
             </div>
           </div>

--- a/src/app/admin/rooms/RoomTile.tsx
+++ b/src/app/admin/rooms/RoomTile.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import { Check, Minus, Pause, Play, Plus, RotateCcw } from "lucide-react";
 import {
   ADJUST_STEP_SECONDS,
@@ -27,58 +28,94 @@ export default function RoomTile({
   room: RoomRow;
   state: RoomState;
   busy: boolean;
-  onAction: (action: TimerAction, deltaSeconds?: number) => void;
+  onAction: (action: TimerAction, valueSeconds?: number) => void;
 }) {
+  const [editingTime, setEditingTime] = useState(false);
+  const [minutesInput, setMinutesInput] = useState("");
   const style = STATUS_STYLES[state.status];
   const displaySeconds =
     state.remainingSeconds ?? room.default_duration_seconds;
   const sessionActive = state.status !== "available";
 
+  const openTimeEditor = () => {
+    if (busy) return;
+    setMinutesInput(String(Math.max(1, Math.round(displaySeconds / 60))));
+    setEditingTime(true);
+  };
+
+  const commitTime = () => {
+    setEditingTime(false);
+    const minutes = Math.min(60, Math.max(1, Number(minutesInput)));
+    if (!Number.isFinite(minutes)) return;
+    onAction("set", Math.round(minutes) * 60);
+  };
+
   return (
     <div
-      className={`${style.card} rounded-2xl p-4 text-white shadow-lg transition-colors duration-500 flex flex-col gap-3 select-none`}
+      className={`${style.card} flex h-full flex-col items-center justify-between overflow-hidden rounded-2xl p-3 text-center text-white shadow-lg transition-colors duration-500 select-none`}
     >
-      <div className="flex items-baseline justify-between gap-2">
-        <h2 className="text-lg font-semibold truncate">{room.name}</h2>
+      <div className="w-full min-w-0">
+        <h2 className="truncate text-base font-semibold">{room.name}</h2>
         {room.practitioner_name && (
-          <span className="text-xs text-white/70 truncate">
+          <p className="truncate text-xs text-white/70">
             {room.practitioner_name}
-          </span>
+          </p>
         )}
       </div>
 
-      <div className="flex items-center justify-center gap-3">
+      <div className="flex w-full items-center justify-center gap-1.5">
         <button
           aria-label="Less time"
           disabled={busy}
           onClick={() => onAction("adjust", -ADJUST_STEP_SECONDS)}
-          className="rounded-full bg-white/15 p-2 hover:bg-white/25 disabled:opacity-40"
+          className="shrink-0 rounded-full bg-white/15 p-1.5 hover:bg-white/25 disabled:opacity-40"
         >
-          <Minus className="h-5 w-5" />
+          <Minus className="h-4 w-4" />
         </button>
-        <span
-          className={`text-4xl font-bold tabular-nums ${
-            state.paused ? "animate-pulse" : ""
-          }`}
-        >
-          {formatTimerDisplay(displaySeconds)}
-        </span>
+        {editingTime ? (
+          <input
+            autoFocus
+            type="number"
+            min={1}
+            max={60}
+            value={minutesInput}
+            onChange={(e) => setMinutesInput(e.target.value)}
+            onBlur={commitTime}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitTime();
+              if (e.key === "Escape") setEditingTime(false);
+            }}
+            aria-label="Minutes"
+            className="w-20 rounded-lg bg-white/15 px-1 py-0.5 text-center text-2xl font-bold tabular-nums outline-none ring-2 ring-white/40 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          />
+        ) : (
+          <button
+            aria-label="Type a time in minutes"
+            disabled={busy}
+            onClick={openTimeEditor}
+            className={`rounded-lg px-1 text-3xl font-bold tabular-nums hover:bg-white/10 disabled:opacity-70 ${
+              state.paused ? "animate-pulse" : ""
+            }`}
+          >
+            {formatTimerDisplay(displaySeconds)}
+          </button>
+        )}
         <button
           aria-label="More time"
           disabled={busy}
           onClick={() => onAction("adjust", ADJUST_STEP_SECONDS)}
-          className="rounded-full bg-white/15 p-2 hover:bg-white/25 disabled:opacity-40"
+          className="shrink-0 rounded-full bg-white/15 p-1.5 hover:bg-white/25 disabled:opacity-40"
         >
-          <Plus className="h-5 w-5" />
+          <Plus className="h-4 w-4" />
         </button>
       </div>
 
-      <div className="flex items-center justify-center gap-2">
+      <div className="flex w-full items-center justify-center gap-1.5">
         {state.status === "available" && (
           <button
             disabled={busy}
             onClick={() => onAction("start")}
-            className="flex items-center gap-1.5 rounded-xl bg-white/20 px-4 py-2 font-medium hover:bg-white/30 disabled:opacity-40"
+            className="flex items-center gap-1.5 rounded-xl bg-white/20 px-3 py-1.5 text-sm font-medium hover:bg-white/30 disabled:opacity-40"
           >
             <Play className="h-4 w-4" /> Start
           </button>
@@ -87,7 +124,7 @@ export default function RoomTile({
           <button
             disabled={busy}
             onClick={() => onAction(state.paused ? "resume" : "pause")}
-            className="flex items-center gap-1.5 rounded-xl bg-white/20 px-4 py-2 font-medium hover:bg-white/30 disabled:opacity-40"
+            className="flex items-center gap-1.5 rounded-xl bg-white/20 px-3 py-1.5 text-sm font-medium hover:bg-white/30 disabled:opacity-40"
           >
             {state.paused ? (
               <>
@@ -106,7 +143,7 @@ export default function RoomTile({
               aria-label="Reset timer"
               disabled={busy}
               onClick={() => onAction("reset")}
-              className="rounded-xl bg-white/15 p-2.5 hover:bg-white/25 disabled:opacity-40"
+              className="rounded-xl bg-white/15 p-2 hover:bg-white/25 disabled:opacity-40"
             >
               <RotateCcw className="h-4 w-4" />
             </button>
@@ -114,15 +151,15 @@ export default function RoomTile({
               aria-label="Clear room"
               disabled={busy}
               onClick={() => onAction("clear")}
-              className="rounded-xl bg-white/90 p-2.5 text-emerald-700 hover:bg-white disabled:opacity-40"
+              className="rounded-xl bg-white/90 p-2 text-emerald-700 hover:bg-white disabled:opacity-40"
             >
-              <Check className="h-5 w-5" />
+              <Check className="h-4 w-4" />
             </button>
           </>
         )}
       </div>
 
-      <p className="text-center text-xs font-semibold uppercase tracking-widest text-white/80">
+      <p className="w-full truncate text-[11px] font-semibold uppercase tracking-widest text-white/80">
         {state.paused ? "Paused" : style.label}
       </p>
     </div>

--- a/src/app/admin/rooms/grid.ts
+++ b/src/app/admin/rooms/grid.ts
@@ -1,0 +1,15 @@
+import type { CSSProperties } from "react";
+import { GRID_COLS } from "@/lib/room-status";
+
+// Single source of truth for the board's grid geometry. The live view and
+// the layout editor must render identical cell sizes and track counts so
+// the layout staff arrange in edit mode is exactly what the live board
+// shows — including empty rows, which need an explicit track height or
+// CSS collapses them and rooms drift upward.
+export const CELL_MIN_WIDTH_PX = 190;
+export const CELL_HEIGHT_PX = 200;
+
+export const gridStyle: CSSProperties = {
+  gridTemplateColumns: `repeat(${GRID_COLS}, minmax(${CELL_MIN_WIDTH_PX}px, 1fr))`,
+  gridAutoRows: `${CELL_HEIGHT_PX}px`,
+};

--- a/src/app/admin/rooms/page.tsx
+++ b/src/app/admin/rooms/page.tsx
@@ -2,7 +2,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, Bell, Pencil, X } from "lucide-react";
-import { deriveRoomState, GRID_COLS } from "@/lib/room-status";
+import { deriveRoomState } from "@/lib/room-status";
+import { gridStyle } from "./grid";
 import { useRooms } from "./useRooms";
 import { useAlarm } from "./useAlarm";
 import RoomTile from "./RoomTile";
@@ -85,16 +86,12 @@ export default function RoomsPage() {
         />
       ) : rooms.length === 0 ? (
         <p className="mx-auto max-w-5xl text-white/60">
-          No rooms yet — tap &quot;Edit layout&quot; to add your first room.
+          No rooms yet — tap &quot;Edit layout&quot;, then &quot;Create
+          room&quot;.
         </p>
       ) : (
         <div className="mx-auto max-w-5xl overflow-x-auto pb-2">
-          <div
-            className="grid gap-3"
-            style={{
-              gridTemplateColumns: `repeat(${GRID_COLS}, minmax(150px, 1fr))`,
-            }}
-          >
+          <div className="grid gap-3" style={gridStyle}>
             {rooms.map((room) => (
               <div
                 key={room.id}

--- a/src/app/admin/rooms/useAlarm.ts
+++ b/src/app/admin/rooms/useAlarm.ts
@@ -2,7 +2,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { deriveRoomState, RoomRow } from "@/lib/room-status";
 
-const CHIME_REPEAT_MS = 45_000;
+const CHIME_REPEAT_MS = 20_000;
+const CHIME_MAX_PLAYS = 5;
 
 // Gentle two-tone chime (A5 → E5 sine, soft envelope) generated with the
 // Web Audio API — no audio asset. Browsers block audio until the user
@@ -29,10 +30,12 @@ function playChime(ctx: AudioContext) {
 export function useAlarm(rooms: RoomRow[], serverNowMs: number) {
   const [soundEnabled, setSoundEnabled] = useState(false);
   const ctxRef = useRef<AudioContext | null>(null);
-  const alarming = rooms.some((room) => {
+  // Count, not boolean: a second room completing while one is already
+  // alarming restarts the chime cycle so it gets heard too.
+  const alarmingCount = rooms.filter((room) => {
     const status = deriveRoomState(room, serverNowMs).status;
     return status === "complete" || status === "overtime";
-  });
+  }).length;
 
   const enableSound = useCallback(() => {
     if (!ctxRef.current) {
@@ -42,13 +45,22 @@ export function useAlarm(rooms: RoomRow[], serverNowMs: number) {
     setSoundEnabled(true);
   }, []);
 
+  // Chime up to 5 times, 20 s apart, per alarm episode — then stay quiet
+  // until the room is cleared (which stops the cycle early) or another
+  // room completes (which starts a fresh cycle).
   useEffect(() => {
-    if (!alarming || !soundEnabled || !ctxRef.current) return;
+    if (alarmingCount === 0 || !soundEnabled || !ctxRef.current) return;
     const ctx = ctxRef.current;
-    playChime(ctx);
-    const interval = setInterval(() => playChime(ctx), CHIME_REPEAT_MS);
+    let plays = 0;
+    const play = () => {
+      playChime(ctx);
+      plays += 1;
+      if (plays >= CHIME_MAX_PLAYS) clearInterval(interval);
+    };
+    const interval = setInterval(play, CHIME_REPEAT_MS);
+    play();
     return () => clearInterval(interval);
-  }, [alarming, soundEnabled]);
+  }, [alarmingCount, soundEnabled]);
 
   // Keep the display awake where the browser allows it (tablets on a wall).
   useEffect(() => {

--- a/src/app/admin/rooms/useRooms.ts
+++ b/src/app/admin/rooms/useRooms.ts
@@ -103,10 +103,14 @@ export function useRooms() {
   );
 
   const timerAction = useCallback(
-    (roomId: string, action: TimerAction, deltaSeconds?: number) =>
+    (roomId: string, action: TimerAction, valueSeconds?: number) =>
       mutate(roomId, `/api/admin/rooms/${roomId}/timer`, {
         method: "POST",
-        body: JSON.stringify({ action, deltaSeconds }),
+        body: JSON.stringify(
+          action === "set"
+            ? { action, setSeconds: valueSeconds }
+            : { action, deltaSeconds: valueSeconds }
+        ),
       }),
     [mutate]
   );

--- a/src/app/api/admin/rooms/[id]/timer/route.ts
+++ b/src/app/api/admin/rooms/[id]/timer/route.ts
@@ -6,14 +6,32 @@ import { broadcastRoomsUpdated } from "@/lib/rooms-realtime";
 import {
   timerActionUpdate,
   ADJUST_STEP_SECONDS,
+  MAX_DURATION_SECONDS,
+  MIN_DURATION_SECONDS,
   RoomRow,
 } from "@/lib/room-status";
 
 const bodySchema = z.object({
-  action: z.enum(["start", "pause", "resume", "reset", "adjust", "clear"]),
+  action: z.enum([
+    "start",
+    "pause",
+    "resume",
+    "reset",
+    "adjust",
+    "set",
+    "clear",
+  ]),
   deltaSeconds: z
     .literal(ADJUST_STEP_SECONDS)
     .or(z.literal(-ADJUST_STEP_SECONDS))
+    .optional(),
+  // "set": absolute seconds typed by staff (new default, or new remaining
+  // on an active session)
+  setSeconds: z
+    .number()
+    .int()
+    .min(MIN_DURATION_SECONDS)
+    .max(MAX_DURATION_SECONDS)
     .optional(),
 });
 
@@ -54,7 +72,9 @@ export async function POST(
     room as RoomRow,
     parsed.data.action,
     Date.now(),
-    parsed.data.deltaSeconds
+    parsed.data.action === "set"
+      ? parsed.data.setSeconds
+      : parsed.data.deltaSeconds
   );
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 409 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import "./ui/globals.css";
-import Header from "@/components/header";
+import ConditionalHeader from "@/components/conditional-header";
 import ConditionalFooter from "@/components/conditional-footer";
 import MotionProvider from "@/components/motion/motion-provider";
 import { instrumentSerif, interTight } from "./ui/fonts";
@@ -31,7 +31,7 @@ export default function RootLayout({
         className={`${instrumentSerif.variable} ${interTight.variable} antialiased`}
       >
         <MotionProvider>
-          <Header />
+          <ConditionalHeader />
           {children}
           <ConditionalFooter />
         </MotionProvider>

--- a/src/components/conditional-header.tsx
+++ b/src/components/conditional-header.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Header from "./header";
+
+export default function ConditionalHeader() {
+  const pathname = usePathname();
+  const isAdminPage = pathname?.startsWith("/admin");
+
+  if (isAdminPage) {
+    return null;
+  }
+
+  return <Header />;
+}

--- a/src/lib/room-status.test.ts
+++ b/src/lib/room-status.test.ts
@@ -150,6 +150,36 @@ describe("timerActionUpdate", () => {
     expect(timerActionUpdate(baseRoom, "adjust", T0).ok).toBe(false);
   });
 
+  it("set on an available room sets the persisted default", () => {
+    const r = timerActionUpdate(baseRoom, "set", T0, 1200);
+    expect(r).toEqual({ ok: true, fields: { default_duration_seconds: 1200 } });
+  });
+
+  it("set clamps to the 60-3600 s range", () => {
+    const r = timerActionUpdate(baseRoom, "set", T0, 30);
+    expect(r).toEqual({ ok: true, fields: { default_duration_seconds: 60 } });
+  });
+
+  it("set on a running room makes the value the new remaining time", () => {
+    const r = timerActionUpdate(running(), "set", T0 + 300_000, 600);
+    expect(r).toEqual({ ok: true, fields: { timer_duration_seconds: 900 } });
+  });
+
+  it("set on a paused room uses the frozen elapsed time", () => {
+    const paused = running({ timer_paused_at: iso(T0 + 120_000) });
+    const r = timerActionUpdate(paused, "set", T0 + 900_000, 300);
+    expect(r).toEqual({ ok: true, fields: { timer_duration_seconds: 420 } });
+  });
+
+  it("set on a completed room brings it back to in_use remaining", () => {
+    const r = timerActionUpdate(running(), "set", T0 + 950_000, 120);
+    expect(r).toEqual({ ok: true, fields: { timer_duration_seconds: 1070 } });
+  });
+
+  it("set requires a value", () => {
+    expect(timerActionUpdate(baseRoom, "set", T0).ok).toBe(false);
+  });
+
   it.each(["reset", "clear"] as const)("%s clears all session fields", (a) => {
     const paused = running({ timer_paused_at: iso(T0 + 100_000) });
     expect(timerActionUpdate(paused, a, T0 + 200_000)).toEqual({

--- a/src/lib/room-status.ts
+++ b/src/lib/room-status.ts
@@ -64,6 +64,7 @@ export type TimerAction =
   | "resume"
   | "reset"
   | "adjust"
+  | "set"
   | "clear";
 
 export type TimerUpdate =
@@ -73,11 +74,14 @@ export type TimerUpdate =
 const clampDuration = (s: number) =>
   Math.min(MAX_DURATION_SECONDS, Math.max(MIN_DURATION_SECONDS, s));
 
+// valueSeconds: for "adjust" it is the signed delta; for "set" it is the
+// absolute value typed by staff — the new default on an available room, or
+// the new remaining time on an active session.
 export function timerActionUpdate(
   room: RoomRow,
   action: TimerAction,
   nowMs: number,
-  deltaSeconds?: number
+  valueSeconds?: number
 ): TimerUpdate {
   const state = deriveRoomState(room, nowMs);
 
@@ -120,7 +124,7 @@ export function timerActionUpdate(
     }
 
     case "adjust": {
-      if (deltaSeconds === undefined || deltaSeconds === 0) {
+      if (valueSeconds === undefined || valueSeconds === 0) {
         return { ok: false, error: "deltaSeconds required" };
       }
       if (state.status === "available") {
@@ -128,19 +132,33 @@ export function timerActionUpdate(
           ok: true,
           fields: {
             default_duration_seconds: clampDuration(
-              room.default_duration_seconds + deltaSeconds
+              room.default_duration_seconds + valueSeconds
             ),
           },
         };
       }
       const next = Math.min(
-        room.timer_duration_seconds! + deltaSeconds,
+        room.timer_duration_seconds! + valueSeconds,
         MAX_DURATION_SECONDS
       );
       if (next < elapsedSeconds(room, nowMs)) {
         return { ok: false, error: "Cannot reduce below elapsed time" };
       }
       return { ok: true, fields: { timer_duration_seconds: next } };
+    }
+
+    case "set": {
+      if (valueSeconds === undefined) {
+        return { ok: false, error: "setSeconds required" };
+      }
+      const value = clampDuration(valueSeconds);
+      if (state.status === "available") {
+        return { ok: true, fields: { default_duration_seconds: value } };
+      }
+      return {
+        ok: true,
+        fields: { timer_duration_seconds: elapsedSeconds(room, nowMs) + value },
+      };
     }
 
     case "reset":


### PR DESCRIPTION
## Summary

Follow-up to #28: the QA polish commit was pushed to `patient-timers` ~40 minutes after that PR was merged, so it never reached `main`. This PR carries exactly that commit, cherry-picked onto current `main`.

- **Public site header no longer renders on `/admin/*` pages** (new `ConditionalHeader`, mirroring `ConditionalFooter`) — fixes the nav overlapping the dashboard, sign-in kiosk, and rooms board
- **Layout editor rework**: "Create room" button (auto-places in first free cell), drag-and-drop room placement (dnd-kit, touch-friendly), click a room to edit, centered tile text
- **Layout retention fix**: live board and editor share one grid geometry with fixed row tracks — empty rows no longer collapse, so the saved arrangement renders exactly as built
- **Tile polish**: compact centered controls that fit inside the tile
- **Numeric time entry**: tap the time to type minutes (new `set` timer action — sets the default on idle rooms, the remaining time on active ones; +6 unit tests)
- **Alarm cadence**: 5 chimes max, 20 s apart, per episode; clearing stops early; a newly completing room restarts the cycle

## Test plan

- [x] 38/38 unit tests, `lint:strict` clean, `next build` succeeds on this branch
- [ ] Preview QA: admin pages header-free, drag-and-drop placement, layout retained on live board, typed time entry, 5-chime alarm

🤖 Generated with [Claude Code](https://claude.com/claude-code)