### PR TITLE
feat(rooms): ring until cleared + flashing done label

### DIFF
--- a/src/app/admin/rooms/RoomTile.tsx
+++ b/src/app/admin/rooms/RoomTile.tsx
@@ -23,11 +23,13 @@ export default function RoomTile({
   room,
   state,
   busy,
+  nowMs,
   onAction,
 }: {
   room: RoomRow;
   state: RoomState;
   busy: boolean;
+  nowMs: number;
   onAction: (action: TimerAction, valueSeconds?: number) => void;
 }) {
   const [editingTime, setEditingTime] = useState(false);
@@ -36,6 +38,17 @@ export default function RoomTile({
   const displaySeconds =
     state.remainingSeconds ?? room.default_duration_seconds;
   const sessionActive = state.status !== "available";
+  const timeUp = state.status === "complete" || state.status === "overtime";
+  // Time's up: flash the label, alternating each second between the room
+  // name and the instruction. The page rerenders every second (nowMs
+  // ticks), so no local timer is needed.
+  const label = timeUp
+    ? Math.floor(nowMs / 1000) % 2 === 0
+      ? `${room.name} done`
+      : "Remove needles"
+    : state.paused
+      ? "Paused"
+      : style.label;
 
   const openTimeEditor = () => {
     if (busy) return;
@@ -159,8 +172,12 @@ export default function RoomTile({
         )}
       </div>
 
-      <p className="w-full truncate text-[11px] font-semibold uppercase tracking-widest text-white/80">
-        {state.paused ? "Paused" : style.label}
+      <p
+        className={`w-full truncate text-[11px] font-semibold uppercase tracking-widest ${
+          timeUp ? "text-white" : "text-white/80"
+        }`}
+      >
+        {label}
       </p>
     </div>
   );

--- a/src/app/admin/rooms/page.tsx
+++ b/src/app/admin/rooms/page.tsx
@@ -104,6 +104,7 @@ export default function RoomsPage() {
                   room={room}
                   state={deriveRoomState(room, serverNowMs)}
                   busy={busyRoomIds.has(room.id)}
+                  nowMs={serverNowMs}
                   onAction={(action, deltaSeconds) =>
                     timerAction(room.id, action, deltaSeconds)
                   }

--- a/src/app/admin/rooms/useAlarm.ts
+++ b/src/app/admin/rooms/useAlarm.ts
@@ -2,14 +2,18 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { deriveRoomState, RoomRow } from "@/lib/room-status";
 
-const CHIME_REPEAT_MS = 20_000;
-const CHIME_MAX_PLAYS = 5;
+// Each alarm "instance" is a burst of 3 chimes; instances repeat with a
+// 20 s pause in between, forever, until the room is cleared.
+const CHIMES_PER_INSTANCE = 3;
+const CHIME_SPACING_S = 1.6;
+const INSTANCE_PAUSE_MS = 20_000;
+const INSTANCE_LENGTH_MS = CHIMES_PER_INSTANCE * CHIME_SPACING_S * 1000;
 
 // Gentle two-tone chime (A5 → E5 sine, soft envelope) generated with the
 // Web Audio API — no audio asset. Browsers block audio until the user
 // interacts with the page, so the page shows an enable-sound button that
 // calls enableSound() (creating the AudioContext inside the tap handler).
-function playChime(ctx: AudioContext) {
+function playChime(ctx: AudioContext, atSeconds: number) {
   const note = (freq: number, at: number) => {
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
@@ -23,8 +27,15 @@ function playChime(ctx: AudioContext) {
     osc.start(ctx.currentTime + at);
     osc.stop(ctx.currentTime + at + 1.3);
   };
-  note(880, 0);
-  note(659.25, 0.35);
+  note(880, atSeconds);
+  note(659.25, atSeconds + 0.35);
+}
+
+// One instance = 3 chimes back to back, scheduled on the audio clock.
+function playInstance(ctx: AudioContext) {
+  for (let i = 0; i < CHIMES_PER_INSTANCE; i++) {
+    playChime(ctx, i * CHIME_SPACING_S);
+  }
 }
 
 const SOUND_PREF_KEY = "rooms-chime-enabled";
@@ -82,21 +93,19 @@ export function useAlarm(rooms: RoomRow[], serverNowMs: number) {
     };
   }, [ensureAudio]);
 
-  // Chime up to 5 times, 20 s apart, per alarm episode — then stay quiet
-  // until the room is cleared (which stops the cycle early) or another
-  // room completes (which starts a fresh cycle).
+  // Ring a 3-chime instance immediately, then again after every 20 s
+  // pause, indefinitely — the only thing that stops it is the alarm
+  // condition ending (staff clears the room). A second room completing
+  // restarts the rhythm so it gets heard too.
   useEffect(() => {
     if (alarmingCount === 0 || !soundEnabled || !audioReady) return;
     const ctx = ctxRef.current;
     if (!ctx) return;
-    let plays = 0;
-    const play = () => {
-      playChime(ctx);
-      plays += 1;
-      if (plays >= CHIME_MAX_PLAYS) clearInterval(interval);
-    };
-    const interval = setInterval(play, CHIME_REPEAT_MS);
-    play();
+    playInstance(ctx);
+    const interval = setInterval(
+      () => playInstance(ctx),
+      INSTANCE_LENGTH_MS + INSTANCE_PAUSE_MS
+    );
     return () => clearInterval(interval);
   }, [alarmingCount, soundEnabled, audioReady]);
 


### PR DESCRIPTION
## Summary

Alarm behavior changes requested after floor testing:

- **Chime cycle**: each instance rings the two-tone chime **3 times** (1.6 s apart); instances are separated by a **20 s pause** and repeat **indefinitely until the room is manually cleared** (✓). A second room completing restarts the rhythm so it's heard too. (Previously: single chime every 20 s, capped at 5, then silence.)
- **Flashing label**: while a room's time is up (Complete or Overtime), the status text under the timer alternates every second between **"ROOM # DONE"** and **"REMOVE NEEDLES"** at full brightness, synced to the shared clock so all devices flash together.

## Test plan

- [x] 38/38 unit tests, `lint:strict` clean, `next build` succeeds
- [ ] Preview QA: run a timer to 0:00 → 3-chime burst immediately, again every ~25 s until ✓ tapped; label alternates ROOM DONE / REMOVE NEEDLES once per second

🤖 Generated with [Claude Code](https://claude.com/claude-code)