### PR TITLE
fix(rooms): iPad crash — CSP blocked Supabase Realtime websocket

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,17 @@
+// The room timer board connects from the browser to Supabase Realtime
+// (wss:// websocket + https:// fallback), so the Supabase project host
+// must be in connect-src. Without it, WebKit (every iPad browser) throws
+// synchronously from the blocked WebSocket constructor and crashes the
+// page, while Chromium just silently loses realtime.
+const supabaseHttp = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+const supabaseWs = supabaseHttp.replace(/^https:/, "wss:");
 const CSP = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob:",
   "font-src 'self'",
-  "connect-src 'self'",
+  `connect-src 'self' ${supabaseHttp} ${supabaseWs}`.replace(/\s+/g, " ").trim(),
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/src/app/admin/rooms/useRooms.ts
+++ b/src/app/admin/rooms/useRooms.ts
@@ -75,26 +75,41 @@ export function useRooms() {
 
   useEffect(() => {
     refresh();
+    // Realtime is an accelerator, never a dependency: if the websocket
+    // cannot be opened (CSP, old browser, network appliance), the board
+    // must still work on the poll. WebKit throws synchronously from a
+    // blocked WebSocket constructor, so the subscribe is guarded.
     const supabase = createBrowserClient();
-    const channel = supabase
-      .channel(ROOMS_CHANNEL)
-      .on("broadcast", { event: ROOMS_EVENT }, (message) => {
-        const payload = message.payload as RoomsBroadcastPayload | undefined;
-        if (payload?.room) {
-          upsertRoom(payload.room);
-        } else if (payload?.deletedId) {
-          removeRoom(payload.deletedId);
-        } else {
-          refresh();
-        }
-      })
-      .subscribe();
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    try {
+      channel = supabase
+        .channel(ROOMS_CHANNEL)
+        .on("broadcast", { event: ROOMS_EVENT }, (message) => {
+          const payload = message.payload as RoomsBroadcastPayload | undefined;
+          if (payload?.room) {
+            upsertRoom(payload.room);
+          } else if (payload?.deletedId) {
+            removeRoom(payload.deletedId);
+          } else {
+            refresh();
+          }
+        })
+        .subscribe();
+    } catch {
+      channel = null;
+    }
     const poll = setInterval(refresh, POLL_MS);
     const onWake = () => refresh();
     window.addEventListener("online", onWake);
     document.addEventListener("visibilitychange", onWake);
     return () => {
-      supabase.removeChannel(channel);
+      if (channel) {
+        try {
+          supabase.removeChannel(channel);
+        } catch {
+          // Channel teardown must never crash unmount either.
+        }
+      }
       clearInterval(poll);
       window.removeEventListener("online", onWake);
       document.removeEventListener("visibilitychange", onWake);


### PR DESCRIPTION
## Root cause

`next.config.js` ships `connect-src 'self'`, which blocks the browser's `wss://` connection to Supabase Realtime (the rooms board is the site's first browser→Supabase connection, so the CSP never mattered before). The two engines fail differently:

- **Chromium (desktop)**: async failure — supabase-js retries quietly, page works, realtime silently dead (every device has actually been on the 60 s poll in production; the PR #32 fast-sync never got to run)
- **WebKit (every iPad browser)**: `new WebSocket()` **throws synchronously** under a CSP block; the exception escapes supabase-js inside the mount effect and React tears the page down → "Application error: a client-side exception has occurred"

Reproduced in headless WebKit (Playwright) against a local prod build with a minted staff session: exact crash, exact error (`WebSocket not available: The operation is insecure`).

## Fix

1. **CSP**: `connect-src` now includes the Supabase project host (`https://` + `wss://`), derived from `NEXT_PUBLIC_SUPABASE_URL` at build time. No other directives touched.
2. **Defense in depth**: `useRooms` wraps channel subscribe/teardown in try/catch — realtime is an accelerator, never a dependency; any future websocket failure degrades to the poll instead of crashing.

## Verification

- [x] WebKit repro: crashes before the fix, renders and polls after
- [x] Chromium: unchanged behavior, websocket now actually connects
- [x] CSP header inspected on local prod build — Supabase hosts present, everything else identical
- [x] 38/38 unit tests, `lint:strict` clean, `next build` succeeds
- [ ] After deploy: open the board on the iPad (should load), and expect cross-device sync to become near-instant everywhere — this deploy is the first time Realtime will actually work in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)